### PR TITLE
Fix heat source strings for heat pumps

### DIFF
--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -264,20 +264,20 @@ class Tank:
             else:
                 self._in_holiday_mode = False
 
-                heat_source = current["heat_source"]
-                heat_source_on = current["immersion"] == "On"
+                heat_source = current["heat_source"].lower()
+                heat_source_on = current["immersion"].lower() == "on"
 
-                if heat_source.lower() == "indirect":
+                if heat_source == "indirect":
                     self._electric_heat_source = False
                     self._heatpump_heat_source = False
                     self._indirect_heat_source = heat_source_on
 
-                elif heat_source.lower() == "electric":
+                elif heat_source == "electric":
                     self._electric_heat_source = heat_source_on
                     self._indirect_heat_source = False
                     self._heatpump_heat_source = False
 
-                elif heat_source.lower() == "heatpump":
+                elif heat_source == "heatpump":
                     self._heatpump_heat_source = heat_source_on
                     self._indirect_heat_source = False
                     self._electric_heat_source = False

--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -267,17 +267,17 @@ class Tank:
                 heat_source = current["heat_source"]
                 heat_source_on = current["immersion"] == "On"
 
-                if heat_source == "Indirect":
+                if heat_source.lower() == "indirect":
                     self._electric_heat_source = False
                     self._heatpump_heat_source = False
                     self._indirect_heat_source = heat_source_on
 
-                elif heat_source == "Electric":
+                elif heat_source.lower() == "electric":
                     self._electric_heat_source = heat_source_on
                     self._indirect_heat_source = False
                     self._heatpump_heat_source = False
 
-                elif heat_source == "HeatPump":
+                elif heat_source.lower() == "heatpump":
                     self._heatpump_heat_source = heat_source_on
                     self._indirect_heat_source = False
                     self._electric_heat_source = False


### PR DESCRIPTION
For my Mixergy tank, when heating via heat pump the source comes through the API as "`Heatpump`". This makes the check not pass.

I figured lowercasing to check here was the best bet all round incase Mixergy change things at any point.