### PR TITLE
Fix medical research enabled switch

### DIFF
--- a/custom_components/mixergy/switch.py
+++ b/custom_components/mixergy/switch.py
@@ -90,7 +90,7 @@ class DistributedComputingSwitch(SwitchEntityBase):
 
     @property
     def is_on(self):
-        return self._tank.dsr_enabled
+        return self._tank.distributed_computing_enabled
 
     async def async_turn_on(self, **kwargs):
         await self._tank.set_distributed_computing_enabled(True)


### PR DESCRIPTION
This was reading from the wrong property of the tank. A bad copy and paste by me.

Fixes #42.