### PR TITLE
Fix PV energy sensor

### DIFF
--- a/custom_components/mixergy/sensor.py
+++ b/custom_components/mixergy/sensor.py
@@ -385,10 +385,10 @@ class PVEnergySensor(IntegrationSensor):
     @property
     def icon(self):
         return "mdi:lightning-bolt"
-    
+
     @property
     def available(self):
-        return super().available and self._tank.has_pv_diverter
+        return self._tank.online and self._tank.has_pv_diverter
 
 class ClampPowerSensor(SensorBase):
 


### PR DESCRIPTION
The PV energy sensor's available method was wrong. `PVEnergySensor` does not inherit from `MixergyEntityBase` so can't call `super().available` to get access to the centralised logic there.

Probably it's best if we try to make those integration sensors inherit from `MixergyEntityBase` too - but that's one for another time.