### PR TITLE
Switch to push

### DIFF
--- a/custom_components/mixergy/__init__.py
+++ b/custom_components/mixergy/__init__.py
@@ -34,19 +34,13 @@ async def async_setup_entry(hass: HomeAssistant, entry:ConfigEntry) -> bool:
 
     """Set up a tank from a config entry."""
 
-    tank = Tank(hass, entry.data[CONF_USERNAME],entry.data[CONF_PASSWORD],entry.data["serial_number"])
+    tank = Tank(hass, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD], entry.data["serial_number"])
 
-    async def async_update_data():
-        _LOGGER.info("Fetching data from Mixergy...")
-        await tank.fetch_data()
-
-    # Create a coordinator to fetch data from the Mixergy API.
-    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="Mixergy", update_method = async_update_data, update_interval = timedelta(seconds=30))
-    await coordinator.async_config_entry_first_refresh()
+    await tank.fetch_data()
+    tank.start()
 
     hass.data[DOMAIN][entry.entry_id] = {
         "tank": tank,
-        "coordinator": coordinator,
     }
 
     _register_services(hass)
@@ -56,6 +50,9 @@ async def async_setup_entry(hass: HomeAssistant, entry:ConfigEntry) -> bool:
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+
+    tank = hass.data[DOMAIN][entry.entry_id]["tank"]
+    tank.stop()
 
     unload_ok = all(
         await asyncio.gather(

--- a/custom_components/mixergy/manifest.json
+++ b/custom_components/mixergy/manifest.json
@@ -6,8 +6,10 @@
     "dependencies": ["integration"],
     "documentation": "https://github.com/tomasmcguinness/homeassistant-mixergy",
     "integration_type": "device",
-    "iot_class": "cloud_polling",
+    "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/tomasmcguinness/homeassistant-mixergy/issues",
-    "requirements": [],
+    "requirements": [
+        "stomp.py"
+    ],
     "version": "0.9.0"
   }

--- a/custom_components/mixergy/mixergy_entity.py
+++ b/custom_components/mixergy/mixergy_entity.py
@@ -1,13 +1,13 @@
 from .const import DOMAIN
 from .tank import Tank
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.entity import Entity
 
-class MixergyEntityBase(CoordinatorEntity):
+class MixergyEntityBase(Entity):
 
-    should_poll = True
+    should_poll = False
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator)        
+    def __init__(self, tank:Tank):
+        super().__init__()
         self._tank = tank
 
     @property
@@ -17,8 +17,8 @@ class MixergyEntityBase(CoordinatorEntity):
             "manufacturer": "Mixergy Ltd",
             "name": "Mixergy Tank",
             "suggested_area": "garage",
-            "model": self._tank.modelCode,
-            "sw_version": self._tank.firmwareVersion
+            "model": self._tank.model_code,
+            "sw_version": self._tank.firmware_version
         }
 
     @property

--- a/custom_components/mixergy/number.py
+++ b/custom_components/mixergy/number.py
@@ -12,24 +12,23 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entry = hass.data[DOMAIN][config_entry.entry_id]
     tank = entry["tank"]
-    coordinator = entry["coordinator"]
 
     new_entities = []
 
-    new_entities.append(TargetTemperatureSensor(coordinator, tank))
-    new_entities.append(TargetChargeSensor(coordinator, tank))
-    new_entities.append(CleansingTemperatureSensor(coordinator, tank))
-    new_entities.append(PVCutInThreshold(coordinator, tank))
-    new_entities.append(PVChargeLimitSensor(coordinator, tank))
-    new_entities.append(PVTargetCurrent(coordinator, tank))
-    new_entities.append(PVOverTemperature(coordinator, tank))
+    new_entities.append(TargetTemperatureSensor(tank))
+    new_entities.append(TargetChargeSensor(tank))
+    new_entities.append(CleansingTemperatureSensor(tank))
+    new_entities.append(PVCutInThreshold(tank))
+    new_entities.append(PVChargeLimitSensor(tank))
+    new_entities.append(PVTargetCurrent(tank))
+    new_entities.append(PVOverTemperature(tank))
 
     async_add_entities(new_entities)
 
 class NumberEntityBase(MixergyEntityBase, NumberEntity):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
 class TargetTemperatureSensor(NumberEntityBase):
 
@@ -39,8 +38,8 @@ class TargetTemperatureSensor(NumberEntityBase):
     device_class = NumberDeviceClass.TEMPERATURE
     native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__( coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -64,8 +63,8 @@ class TargetChargeSensor(NumberEntityBase):
     native_step = 1
     native_unit_of_measurement = PERCENTAGE
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -94,8 +93,8 @@ class CleansingTemperatureSensor(NumberEntityBase):
     device_class = NumberDeviceClass.TEMPERATURE
     native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__( coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -118,8 +117,8 @@ class PVCutInThreshold(NumberEntityBase):
     native_min_value = 0
     native_step = 50
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -150,8 +149,8 @@ class PVChargeLimitSensor(NumberEntityBase):
     native_min_value = 0
     native_step = 10
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -182,8 +181,8 @@ class PVTargetCurrent(NumberEntityBase):
     native_min_value = -1
     native_step = 0.1
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -214,8 +213,8 @@ class PVOverTemperature(NumberEntityBase):
     native_min_value = 45
     native_step = 1
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):

--- a/custom_components/mixergy/sensor.py
+++ b/custom_components/mixergy/sensor.py
@@ -16,47 +16,46 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entry = hass.data[DOMAIN][config_entry.entry_id]
     tank = entry["tank"]
-    coordinator = entry["coordinator"]
 
     new_entities = []
 
-    new_entities.append(HotWaterTemperatureSensor(coordinator, tank))
-    new_entities.append(ColdestWaterTemperatureSensor(coordinator, tank))
-    new_entities.append(ChargeSensor(coordinator, tank))
-    new_entities.append(TargetChargeSensor(coordinator, tank))
-    new_entities.append(ElectricHeatSensor(coordinator, tank))
-    new_entities.append(IndirectHeatSensor(coordinator, tank))
-    new_entities.append(HeatPumpHeatSensor(coordinator,tank))
-    new_entities.append(LowChargeSensor(coordinator, tank))
-    new_entities.append(NoChargeSensor(coordinator, tank))
-    new_entities.append(PowerSensor(coordinator, tank))
-    new_entities.append(EnergySensor(hass, tank))
-    new_entities.append(TargetTemperatureSensor(coordinator, tank))
-    new_entities.append(HolidayModeSensor(coordinator, tank))
-    new_entities.append(PVPowerSensor(coordinator, tank))
-    new_entities.append(PVEnergySensor(hass, tank))
-    new_entities.append(ClampPowerSensor(coordinator, tank))
-    new_entities.append(IsChargingSensor(coordinator, tank))
-    new_entities.append(HolidayStartDateSensor(coordinator, tank))
-    new_entities.append(HolidayEndDateSensor(coordinator, tank))
-    new_entities.append(DefaultHeatSourceSensor(coordinator, tank))
+    new_entities.append(HotWaterTemperatureSensor(tank))
+    new_entities.append(ColdestWaterTemperatureSensor(tank))
+    new_entities.append(ChargeSensor(tank))
+    new_entities.append(TargetChargeSensor(tank))
+    new_entities.append(ElectricHeatSensor(tank))
+    new_entities.append(IndirectHeatSensor(tank))
+    new_entities.append(HeatPumpHeatSensor(tank))
+    new_entities.append(LowChargeSensor(tank))
+    new_entities.append(NoChargeSensor(tank))
+    new_entities.append(PowerSensor(tank))
+    new_entities.append(EnergySensor(tank))
+    new_entities.append(TargetTemperatureSensor(tank))
+    new_entities.append(HolidayModeSensor(tank))
+    new_entities.append(PVPowerSensor(tank))
+    new_entities.append(PVEnergySensor(tank))
+    new_entities.append(ClampPowerSensor(tank))
+    new_entities.append(IsChargingSensor(tank))
+    new_entities.append(HolidayStartDateSensor(tank))
+    new_entities.append(HolidayEndDateSensor(tank))
+    new_entities.append(DefaultHeatSourceSensor(tank))
 
     async_add_entities(new_entities)
 
 class SensorBase(MixergyEntityBase, SensorEntity):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
 class BinarySensorBase(MixergyEntityBase, BinarySensorEntity):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
 class ChargeSensor(SensorBase):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -80,8 +79,8 @@ class ChargeSensor(SensorBase):
 
 class TargetChargeSensor(SensorBase):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -107,8 +106,8 @@ class HotWaterTemperatureSensor(SensorBase):
 
     device_class = SensorDeviceClass.TEMPERATURE
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__( coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -131,8 +130,8 @@ class ColdestWaterTemperatureSensor(SensorBase):
 
     device_class = SensorDeviceClass.TEMPERATURE
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -154,8 +153,8 @@ class TargetTemperatureSensor(SensorBase):
 
     device_class = SensorDeviceClass.TEMPERATURE
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -177,8 +176,8 @@ class IndirectHeatSensor(BinarySensorBase):
 
     device_class = BinarySensorDeviceClass.HEAT
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__( coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -200,8 +199,8 @@ class ElectricHeatSensor(BinarySensorBase):
 
     device_class = SensorDeviceClass.ENERGY
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__( coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = STATE_OFF
 
     @property
@@ -220,8 +219,8 @@ class HeatPumpHeatSensor(BinarySensorBase):
 
     device_class = SensorDeviceClass.ENERGY
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__( coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = STATE_OFF
 
     @property
@@ -238,8 +237,8 @@ class HeatPumpHeatSensor(BinarySensorBase):
 
 class NoChargeSensor(BinarySensorBase):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__( coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = STATE_OFF
 
     @property
@@ -260,8 +259,8 @@ class NoChargeSensor(BinarySensorBase):
 
 class LowChargeSensor(BinarySensorBase):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__( coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = STATE_OFF
 
     @property
@@ -282,8 +281,8 @@ class LowChargeSensor(BinarySensorBase):
 
 class IsChargingSensor(BinarySensorBase):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__( coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = STATE_OFF
 
     @property
@@ -307,8 +306,8 @@ class PowerSensor(SensorBase):
     device_class = SensorDeviceClass.POWER
     state_class = "measurement"
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator,tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = 0
 
     @property
@@ -351,8 +350,8 @@ class PVPowerSensor(SensorBase):
     device_class = SensorDeviceClass.POWER
     state_class = "measurement"
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator,tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = 0
 
     @property
@@ -404,8 +403,8 @@ class ClampPowerSensor(SensorBase):
     device_class = SensorDeviceClass.POWER
     state_class = "measurement"
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator,tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = 0
 
     @property
@@ -430,8 +429,8 @@ class ClampPowerSensor(SensorBase):
 
 class HolidayModeSensor(BinarySensorBase):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__( coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = STATE_OFF
 
     @property
@@ -454,8 +453,8 @@ class HolidayStartDateSensor(SensorBase):
 
     device_class = SensorDeviceClass.TIMESTAMP
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator,tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = None
 
     @property
@@ -474,8 +473,8 @@ class HolidayEndDateSensor(SensorBase):
 
     device_class = SensorDeviceClass.TIMESTAMP
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator,tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = None
 
     @property
@@ -494,8 +493,8 @@ class DefaultHeatSourceSensor(SensorBase):
 
     device_class = SensorDeviceClass.ENUM
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator,tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
         self._state = None
 
     @property

--- a/custom_components/mixergy/sensor.py
+++ b/custom_components/mixergy/sensor.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import timedelta
 from homeassistant.const import UnitOfPower, UnitOfTemperature, PERCENTAGE, STATE_OFF
-from homeassistant.core import HomeAssistant
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.components.integration.sensor import IntegrationSensor
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
@@ -328,9 +327,8 @@ class PowerSensor(SensorBase):
 
 class EnergySensor(IntegrationSensor):
 
-    def __init__(self, hass: HomeAssistant, tank:Tank):
+    def __init__(self, tank:Tank):
         super().__init__(
-            #hass = hass,
             name="Mixergy Electric Heat Energy",
             source_entity="sensor.mixergy_electric_heat_power",
             round_digits=2,
@@ -376,9 +374,8 @@ class PVPowerSensor(SensorBase):
 
 class PVEnergySensor(IntegrationSensor):
 
-    def __init__(self, hass: HomeAssistant, tank:Tank):
+    def __init__(self, tank:Tank):
         super().__init__(
-            #hass = hass,
             name="Mixergy Electric PV Energy",
             source_entity="sensor.mixergy_electric_pv_power",
             round_digits=2,

--- a/custom_components/mixergy/switch.py
+++ b/custom_components/mixergy/switch.py
@@ -14,6 +14,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     new_entities = []
 
+    new_entities.append(MaintainTargetTemperatureSwitch(tank))
     new_entities.append(DSRSwitch(tank))
     new_entities.append(FrostProtectionSwitch(tank))
     new_entities.append(DistributedComputingSwitch(tank))
@@ -27,6 +28,29 @@ class SwitchEntityBase(MixergyEntityBase, SwitchEntity):
 
     def __init__(self, tank:Tank):
         super().__init__(tank)
+
+class MaintainTargetTemperatureSwitch(SwitchEntityBase):
+
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
+
+    @property
+    def unique_id(self):
+        return f"mixergy_{self._tank.tank_id}_target_temperature_control_enabled"
+
+    @property
+    def name(self):
+        return f"Maintain Target Temperature Enabled"
+
+    @property
+    def is_on(self):
+        return self._tank.target_temperature_control_enabled
+
+    async def async_turn_on(self, **kwargs):
+        await self._tank.set_target_temperature_control_enabled(True)
+
+    async def async_turn_off(self, **kwargs):
+        await self._tank.set_target_temperature_control_enabled(False)
 
 class DSRSwitch(SwitchEntityBase):
 

--- a/custom_components/mixergy/switch.py
+++ b/custom_components/mixergy/switch.py
@@ -11,14 +11,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entry = hass.data[DOMAIN][config_entry.entry_id]
     tank = entry["tank"]
-    coordinator = entry["coordinator"]
 
     new_entities = []
 
-    new_entities.append(DSRSwitch(coordinator, tank))
-    new_entities.append(FrostProtectionSwitch(coordinator, tank))
-    new_entities.append(DistributedComputingSwitch(coordinator, tank))
-    new_entities.append(PVDivertSwitch(coordinator, tank))
+    new_entities.append(DSRSwitch(tank))
+    new_entities.append(FrostProtectionSwitch(tank))
+    new_entities.append(DistributedComputingSwitch(tank))
+    new_entities.append(PVDivertSwitch(tank))
 
     async_add_entities(new_entities)
 
@@ -26,13 +25,13 @@ class SwitchEntityBase(MixergyEntityBase, SwitchEntity):
 
     device_class = SwitchDeviceClass.SWITCH
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
 class DSRSwitch(SwitchEntityBase):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -54,8 +53,8 @@ class DSRSwitch(SwitchEntityBase):
 
 class FrostProtectionSwitch(SwitchEntityBase):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -77,8 +76,8 @@ class FrostProtectionSwitch(SwitchEntityBase):
 
 class DistributedComputingSwitch(SwitchEntityBase):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):
@@ -100,8 +99,8 @@ class DistributedComputingSwitch(SwitchEntityBase):
 
 class PVDivertSwitch(SwitchEntityBase):
 
-    def __init__(self, coordinator, tank:Tank):
-        super().__init__(coordinator, tank)
+    def __init__(self, tank:Tank):
+        super().__init__(tank)
 
     @property
     def unique_id(self):

--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -361,6 +361,10 @@ class Tank:
                 _LOGGER.error("Failed to connect to Mixergy STOMP server")
                 self._hass.loop.call_later(STOMP_RETRY_TIMER, self._start_connection)
 
+            except Exception as e:
+                _LOGGER.error(f"Unexpected exception connecting to Mixergy STOMP server:\n{e}")
+                self._hass.loop.call_later(STOMP_RETRY_TIMER, self._start_connection)
+
             self._stomp_conn = stomp_conn
 
         self._stomp_conn_task = self._hass.loop.create_task(_connection_runner())

--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -347,7 +347,8 @@ class Tank:
 
             try:
                 headers = {'Token': self._token}
-                stomp_conn.connect(wait=True, headers=headers, with_connect_command=True)
+                stomp_conn.connect(headers=headers, with_connect_command=True)
+                stomp_conn.transport.wait_for_connection(timeout=60)
                 _LOGGER.debug("STOMP connected")
 
                 topic = f'/topic/tank/{self._uuid}/poll'

--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -313,7 +313,7 @@ class Tank:
 
                 def on_disconnected(self):
                     _LOGGER.debug("STOMP connection: on_disconnected")
-                    self._stomp_conn = None
+                    self._tank._stomp_conn = None
                     self._tank._hass.loop.call_later(STOMP_RETRY_TIMER, self._tank._start_connection)
 
                 def on_message(self, frame):

--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -299,7 +299,9 @@ class Tank:
         async def _connection_runner() -> None:
             _LOGGER.debug("STOMP starting connection")
 
-            await self._authenticate()
+            # Fetch data before connecting so that we have an up-to-date state
+            # since the STOMP connection will only give us changes.
+            await self.fetch_data()
 
             host_tuples = [(STOMP_ENDPOINT, 443)]
             stomp_conn = stomp.WSConnection(host_tuples, ws_path=STOMP_WS_PATH)

--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -311,6 +311,7 @@ class Tank:
 
                 def on_disconnected(self):
                     _LOGGER.debug("STOMP connection: on_disconnected")
+                    self._stomp_conn = None
                     self._tank._hass.loop.call_later(STOMP_RETRY_TIMER, self._tank._start_connection)
 
                 def on_message(self, frame):

--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -1,4 +1,5 @@
 import logging
+import aiohttp
 import asyncio
 import json
 import stomp
@@ -7,10 +8,12 @@ from typing import Optional
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 from .const import ATTR_CHARGE
+from stomp.adapter.ws import websocket
 
 _LOGGER = logging.getLogger(__name__)
 
 ROOT_ENDPOINT = "https://www.mixergy.io/api/v2"
+REQUEST_TIMEOUT = 60
 STOMP_ENDPOINT = "www.mixergy.io"
 STOMP_WS_PATH = "/api/v1/stomp"
 STOMP_RETRY_TIMER = 15
@@ -25,6 +28,7 @@ class Tank:
 
     def __init__(self, hass, username, password, serial_number):
         self._hass = hass
+        self._session = aiohttp_client.async_get_clientsession(hass, verify_ssl=False)
 
         # Internal data
         self._callbacks = set()
@@ -93,89 +97,51 @@ class Tank:
 
     async def test_connection(self):
         return await self._fetch_tank_information()
-    
-    async def set_target_charge(self, charge):
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
+    async def _tank_request_put(self, url, json):
 
         headers = {'Authorization': f'Bearer {self._token}'}
 
-        async with session.put(self._control_url, headers=headers, json={'charge': charge }) as resp:
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT), self._session.put(url, headers=headers, json=json) as resp:
+                if resp.status != 200:
+                    _LOGGER.error("Call to %s failed with status %i", url, resp.status)
+                    return False
 
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set the desired charge failed with status %i", self._control_url, resp.status)
-                return
+                return True
 
+        except TimeoutError:
+            _LOGGER.debug("Timeout calling %s", url)
+            return False
+    
+    async def set_target_charge(self, charge):
+
+        if await self._tank_request_put(self._control_url, {'charge': charge}):
             await self._fetch_last_measurement()
 
     async def set_target_temperature(self, temperature):
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._settings_url, headers=headers, json={'max_temp': temperature }) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set the target temperature failed with status %i", self._settings_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._settings_url, {'max_temp': temperature}):
             await self._fetch_settings()
 
     async def set_target_temperature_control_enabled(self, enabled):
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._settings_url, headers=headers, json={'target_temperature_control_enabled': enabled }) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set maintain target temperature enabled failed with status %i", self._settings_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._settings_url, {'target_temperature_control_enabled': enabled}):
             await self._fetch_settings()
 
     async def set_dsr_enabled(self, enabled):
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._settings_url, headers=headers, json={'dsr_enabled': enabled }) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set dsr (grid assistance) enabled failed with status %i", self._settings_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._settings_url, {'dsr_enabled': enabled}):
             await self._fetch_settings()
 
     async def set_frost_protection_enabled(self, enabled):
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._settings_url, headers=headers, json={'frost_protection_enabled': enabled }) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set frost protection enabled failed with status %i", self._settings_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._settings_url, {'frost_protection_enabled': enabled}):
             await self._fetch_settings()
 
     async def set_distributed_computing_enabled(self, enabled):
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._settings_url, headers=headers, json={'distributed_computing_enabled': enabled }) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set distributed computing (medical research) enabled failed with status %i", self._settings_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._settings_url, {'distributed_computing_enabled': enabled}):
             await self._fetch_settings()
 
     async def set_cleansing_temperature(self, value):
@@ -184,30 +150,12 @@ class Tank:
         value = min(value, 55)
         value = max(value, 51)
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._settings_url, headers=headers, json={'cleansing_temperature': value }) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set cleansing temperature failed with status %i", self._settings_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._settings_url, {'cleansing_temperature': value}):
             await self._fetch_settings()
 
     async def set_divert_exported_enabled(self, enabled):
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._settings_url, headers=headers, json={'divert_exported_enabled': enabled }) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set divert export enabled failed with status %i", self._settings_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._settings_url, {'divert_exported_enabled': enabled}):
             await self._fetch_settings()
 
     async def set_pv_cut_in_threshold(self, value):
@@ -216,16 +164,7 @@ class Tank:
         value = min(value, 500)
         value = max(value, 0)
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._settings_url, headers=headers, json={'pv_cut_in_threshold': value }) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set PV cut in threshold failed with status %i", self._control_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._settings_url, {'pv_cut_in_threshold': value}):
             await self._fetch_settings()
 
     async def set_pv_charge_limit(self, value):
@@ -234,16 +173,7 @@ class Tank:
         value = min(value, 100)
         value = max(value, 0)
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._settings_url, headers=headers, json={'pv_charge_limit': value }) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set PV charge limit failed with status %i", self._control_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._settings_url, {'pv_charge_limit': value}):
             await self._fetch_settings()
 
     async def set_pv_target_current(self, value):
@@ -252,16 +182,7 @@ class Tank:
         value = min(value, 0)
         value = max(value, -1)
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._settings_url, headers=headers, json={'pv_target_current': value }) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set PV target current failed with status %i", self._control_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._settings_url, {'pv_target_current': value}):
             await self._fetch_settings()
 
     async def set_pv_over_temperature(self, value):
@@ -270,16 +191,7 @@ class Tank:
         value = min(value, 60)
         value = max(value, 45)
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._settings_url, headers=headers, json={'pv_over_temperature': value }) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set PV over temperature failed with status %i", self._control_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._settings_url, {'pv_over_temperature': value}):
             await self._fetch_settings()
 
     @callback
@@ -304,7 +216,9 @@ class Tank:
             await self.fetch_data()
 
             host_tuples = [(STOMP_ENDPOINT, 443)]
+            _LOGGER.debug("STOMP creating connection")
             stomp_conn = stomp.WSConnection(host_tuples, ws_path=STOMP_WS_PATH)
+            _LOGGER.debug("STOMP connection setting SSL")
             stomp_conn.set_ssl(host_tuples)
 
             class StompListener(stomp.listener.ConnectionListener):
@@ -345,11 +259,26 @@ class Tank:
                     self._tank._hass.loop.create_task(self._tank._publish_updates())
 
             listener = StompListener(self)
+            _LOGGER.debug("STOMP connection setting listener")
             stomp_conn.set_listener("listener", listener)
 
             try:
                 headers = {'Token': self._token}
+
+                # We do this dance setting the default timeout to 15, then connecting, then setting
+                # the timeout on the underlying socket to `None` because there is no other way to
+                # ensure that the call to `connect` doesn't block forever if the connection cannot
+                # be made. The dance here will ensure that the call to `connect` times-out if it
+                # takes longer than 15 seconds, but then the socket is set to never timeout so that
+                # it stays connected forever.
+                _LOGGER.debug("STOMP connecting socket")
+                websocket_default_timeout = websocket.getdefaulttimeout()
+                websocket.setdefaulttimeout(15)
                 stomp_conn.connect(headers=headers, with_connect_command=True)
+                stomp_conn.transport.socket.timeout = None
+                websocket.setdefaulttimeout(websocket_default_timeout)
+
+                _LOGGER.debug("STOMP waiting for transport connection")
                 stomp_conn.transport.wait_for_connection(timeout=60)
                 _LOGGER.debug("STOMP connected")
 
@@ -388,55 +317,59 @@ class Tank:
             _LOGGER.info("Authentication token is valid")
             return True
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT):
 
-        async with session.get(ROOT_ENDPOINT) as resp:
+                async with self._session.get(ROOT_ENDPOINT) as resp:
 
-            if resp.status != 200:
-                _LOGGER.error("Fetch of root at %s failed with status code %i", ROOT_ENDPOINT, resp.status)
-                return False
+                    if resp.status != 200:
+                        _LOGGER.error("Fetch of root at %s failed with status code %i", ROOT_ENDPOINT, resp.status)
+                        return False
 
-            root_result = await resp.json()
+                    root_result = await resp.json()
 
-            self._account_url = root_result["_links"]["account"]["href"]
+                    self._account_url = root_result["_links"]["account"]["href"]
 
-            _LOGGER.info("Account URL: %s", self._account_url)
+                    _LOGGER.info("Account URL: %s", self._account_url)
 
-            async with session.get(self._account_url) as resp:
+                    async with self._session.get(self._account_url) as resp:
 
-                if resp.status != 200:
-                    _LOGGER.error("Fetch of account at %s failed with status code %i", self._account_url, resp.status)
-                    return False
+                        if resp.status != 200:
+                            _LOGGER.error("Fetch of account at %s failed with status code %i", self._account_url, resp.status)
+                            return False
 
-                account_result = await resp.json()
+                        account_result = await resp.json()
 
-                self._login_url = account_result["_links"]["login"]["href"]
+                        self._login_url = account_result["_links"]["login"]["href"]
 
-                _LOGGER.info("Login URL: %s", self._login_url)
+                        _LOGGER.info("Login URL: %s", self._login_url)
 
-        async with session.post(self._login_url, json={'username': self.username, 'password': self.password}) as resp:
+                async with self._session.post(self._login_url, json={'username': self.username, 'password': self.password}) as resp:
 
-            if resp.status != 201:
-                _LOGGER.error("Authentication failed with status code %i", resp.status)
-                return False
+                    if resp.status != 201:
+                        _LOGGER.error("Authentication failed with status code %i", resp.status)
+                        return False
 
-            login_result = await resp.json()
-            token = login_result['token']
-            self._token = token
+                    login_result = await resp.json()
+                    token = login_result['token']
+                    self._token = token
 
-            return True
+                    return True
+
+        except TimeoutError:
+            _LOGGER.debug("Timeout while authenticating")
 
     async def _fetch_tank_information(self):
+
+        _LOGGER.debug("Fetching tank information")
 
         if self._latest_measurement_url:
             _LOGGER.info("Tank information has already been fetched")
             return
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
         headers = {'Authorization': f'Bearer {self._token}'}
 
-        async with session.get(ROOT_ENDPOINT, headers=headers) as resp:
+        async with asyncio.timeout(REQUEST_TIMEOUT), self._session.get(ROOT_ENDPOINT, headers=headers) as resp:
 
             if resp.status != 200:
                 _LOGGER.error("Fetch of root at %s failed with status code %i", ROOT_ENDPOINT, resp.status)
@@ -446,7 +379,7 @@ class Tank:
 
             self._tanks_url = root_result["_links"]["tanks"]["href"]
 
-        async with session.get(self._tanks_url, headers=headers) as resp:
+        async with asyncio.timeout(REQUEST_TIMEOUT), self._session.get(self._tanks_url, headers=headers) as resp:
 
             if resp.status != 200:
                 _LOGGER.error("Fetch of tanks at %s failed with status code %i", self._tanks_url, resp.status)
@@ -472,7 +405,7 @@ class Tank:
 
             tank_url = tank["_links"]["self"]["href"]
 
-            async with session.get(tank_url, headers=headers) as resp:
+            async with self._session.get(tank_url, headers=headers) as resp:
 
                 if resp.status != 200:
                     _LOGGER.error("Fetch of the tanks details at %s failed with status %i", tank_url, resp.status)
@@ -507,21 +440,30 @@ class Tank:
 
     async def _fetch_last_measurement(self, publish = False):
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
+        _LOGGER.debug("Fetching last measurement")
 
         headers = {'Authorization': f'Bearer {self._token}'}
 
-        async with session.get(self._latest_measurement_url, headers=headers) as resp:
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT), self._session.get(self._latest_measurement_url, headers=headers, timeout=REQUEST_TIMEOUT) as resp:
 
-            if resp.status != 200:
-                _LOGGER.info("Fetch of the latest measurement at %s failed with status %i", self._latest_measurement_url, resp.status)
-                return
+                if resp.status != 200:
+                    _LOGGER.info("Fetch of the latest measurement at %s failed with status %i", self._latest_measurement_url, resp.status)
+                    return
 
-            tank_result = await resp.json()
-            self._update_from_latest_measurement(tank_result)
+                _LOGGER.debug(f"Fetching last measurement response:\n{resp.status}\n{resp}")
 
-            if publish:
-                await self._publish_updates
+                tank_result = await resp.json()
+                self._update_from_latest_measurement(tank_result)
+
+                if publish:
+                    await self._publish_updates()
+
+        except TimeoutError:
+            _LOGGER.debug("Timeout fetching last measurement")
+        
+        except Exception as e:
+            _LOGGER.debug(f"Unhandled exception:\n{e}\n{e.with_traceback()}")
 
     def _update_from_latest_measurement(self, tank_result):
 
@@ -619,24 +561,28 @@ class Tank:
 
     async def _fetch_settings(self, publish = False):
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
+        _LOGGER.debug("Fetching settings")
 
         headers = {'Authorization': f'Bearer {self._token}'}
 
-        async with session.get(self._settings_url, headers=headers) as resp:
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT), self._session.get(self._settings_url, headers=headers) as resp:
 
-            if resp.status != 200:
-                _LOGGER.info("Fetch of the settings %s failed with status %i", self._settings_url, resp.status)
-                return
+                if resp.status != 200:
+                    _LOGGER.info("Fetch of the settings %s failed with status %i", self._settings_url, resp.status)
+                    return
 
-            # The settings API returns text/plain as the content-type, so using the resp.json() fails.
-            # Load it as a bit of JSON via the text.
-            response_text = await resp.text()
-            json_object = json.loads(response_text)
-            self._update_from_new_settings(json_object)
+                # The settings API returns text/plain as the content-type, so using the resp.json() fails.
+                # Load it as a bit of JSON via the text.
+                response_text = await resp.text()
+                json_object = json.loads(response_text)
+                self._update_from_new_settings(json_object)
 
-            if publish:
-                await self._publish_updates
+                if publish:
+                    await self._publish_updates()
+
+        except TimeoutError:
+            _LOGGER.debug("Timeout fetching settings")
 
     def _update_from_new_settings(self, json_object):
 
@@ -661,24 +607,28 @@ class Tank:
 
     async def _fetch_schedule(self, publish = False):
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
+        _LOGGER.debug("Fetching schedule")
 
         headers = {'Authorization': f'Bearer {self._token}'}
 
-        async with session.get(self._schedule_url, headers=headers) as resp:
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT), self._session.get(self._schedule_url, headers=headers) as resp:
 
-            if resp.status != 200:
-                _LOGGER.info("Fetch of the schedule %s failed with status %i", self._schedule_url, resp.status)
-                return
+                if resp.status != 200:
+                    _LOGGER.info("Fetch of the schedule %s failed with status %i", self._schedule_url, resp.status)
+                    return
 
-            # The schedule API returns text/plain as the content-type, so using the resp.json() fails.
-            # Load it as a bit of JSON via the text.
-            response_text = await resp.text()
-            json_object = json.loads(response_text)
-            self._update_from_new_schedule(json_object)
+                # The schedule API returns text/plain as the content-type, so using the resp.json() fails.
+                # Load it as a bit of JSON via the text.
+                response_text = await resp.text()
+                json_object = json.loads(response_text)
+                self._update_from_new_schedule(json_object)
 
-            if publish:
-                await self._publish_updates
+                if publish:
+                    await self._publish_updates()
+
+        except TimeoutError:
+            _LOGGER.debug("Timeout fetching schedule")
 
     def _update_from_new_schedule(self, json_object):
 
@@ -689,16 +639,7 @@ class Tank:
 
     async def set_schedule(self, value):
 
-        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
-
-        headers = {'Authorization': f'Bearer {self._token}'}
-
-        async with session.put(self._schedule_url, headers=headers, json=value) as resp:
-
-            if resp.status != 200:
-                _LOGGER.error("Call to %s to set schedule failed with status %i", self._schedule_url, resp.status)
-                return
-
+        if await self._tank_request_put(self._schedule_url, value):
             await self._fetch_schedule()
 
     async def set_holiday_dates(self, start_date: datetime, end_date: datetime):

--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -36,6 +36,7 @@ class Tank:
         self._should_connect = False
         self._stomp_conn: stomp.WSConnection | None = None
         self._stomp_conn_task: asyncio.Task | None = None
+        self._stomp_retry_handle: asyncio.TimerHandle | None = None
 
         # Parameters
         self.username = username
@@ -204,99 +205,144 @@ class Tank:
     @callback
     def _start_connection(self):
 
+        if self._stomp_retry_handle is not None:
+            self._stomp_retry_handle.cancel()
+            self._stomp_retry_handle = None
+
         if not self._should_connect:
             _LOGGER.debug("Not starting STOMP connection")
+            return
+
+        if self._stomp_conn is not None:
+            _LOGGER.debug("STOMP connection already active")
+            return
+
+        if self._stomp_conn_task is not None and not self._stomp_conn_task.done():
+            _LOGGER.debug("STOMP connection attempt already in progress")
             return
 
         async def _connection_runner() -> None:
             _LOGGER.debug("STOMP starting connection")
 
-            # Fetch data before connecting so that we have an up-to-date state
-            # since the STOMP connection will only give us changes.
-            await self.fetch_data()
-
-            host_tuples = [(STOMP_ENDPOINT, 443)]
-            _LOGGER.debug("STOMP creating connection")
-            stomp_conn = stomp.WSConnection(host_tuples, ws_path=STOMP_WS_PATH)
-            _LOGGER.debug("STOMP connection setting SSL")
-            stomp_conn.set_ssl(host_tuples)
-
-            class StompListener(stomp.listener.ConnectionListener):
-                def __init__(self, tank: Tank):
-                    self._tank = tank
-
-                def on_disconnected(self):
-                    _LOGGER.debug("STOMP connection: on_disconnected")
-                    self._tank._stomp_conn = None
-                    self._tank._hass.loop.call_later(STOMP_RETRY_TIMER, self._tank._start_connection)
-
-                def on_message(self, frame):
-                    _LOGGER.debug("STOMP connection: on_message")
-                    _LOGGER.debug(frame.body)
-
-                    message = json.loads(frame.body)
-                    type = message["type"]
-                    payload = message["payload"]
-
-                    if type == "Measurement":
-                        self._tank._update_from_latest_measurement(payload)
-
-                    elif type == "Event":
-                        event = payload["event"]
-
-                        if event == "Settings":
-                            additional = json.loads(payload["additional"])
-                            self._tank._update_from_new_settings(additional)
-
-                        elif event == "Schedule":
-                            additional = json.loads(payload["additional"])
-                            self._tank._update_from_new_schedule(additional)
-
-                        elif event == "State":
-                            additional = json.loads(payload["additional"])
-                            self._tank._update_from_new_state(additional)
-
-                    self._tank._hass.loop.create_task(self._tank._publish_updates())
-
-            listener = StompListener(self)
-            _LOGGER.debug("STOMP connection setting listener")
-            stomp_conn.set_listener("listener", listener)
-
             try:
-                headers = {'Token': self._token}
-
                 # We do this dance setting the default timeout to 15, then connecting, then setting
                 # the timeout on the underlying socket to `None` because there is no other way to
                 # ensure that the call to `connect` doesn't block forever if the connection cannot
                 # be made. The dance here will ensure that the call to `connect` times-out if it
                 # takes longer than 15 seconds, but then the socket is set to never timeout so that
                 # it stays connected forever.
-                _LOGGER.debug("STOMP connecting socket")
-                websocket_default_timeout = websocket.getdefaulttimeout()
-                websocket.setdefaulttimeout(15)
-                stomp_conn.connect(headers=headers, with_connect_command=True)
-                stomp_conn.transport.socket.timeout = None
-                websocket.setdefaulttimeout(websocket_default_timeout)
+                # Fetch data before connecting so that we have an up-to-date state
+                # since the STOMP connection will only give us changes.
+                await self.fetch_data()
 
-                _LOGGER.debug("STOMP waiting for transport connection")
-                stomp_conn.transport.wait_for_connection(timeout=60)
-                _LOGGER.debug("STOMP connected")
+                host_tuples = [(STOMP_ENDPOINT, 443)]
+                _LOGGER.debug("STOMP creating connection")
+                stomp_conn = stomp.WSConnection(host_tuples, ws_path=STOMP_WS_PATH)
+                _LOGGER.debug("STOMP connection setting SSL")
+                stomp_conn.set_ssl(host_tuples)
 
+                class StompListener(stomp.listener.ConnectionListener):
+                    def __init__(self, tank: Tank):
+                        self._tank = tank
+
+                    def on_disconnected(self):
+                        _LOGGER.debug("STOMP connection: on_disconnected")
+                        self._tank._stomp_conn = None
+                        self._tank._hass.loop.call_soon_threadsafe(self._tank._schedule_reconnect)
+
+                    def on_message(self, frame):
+                        _LOGGER.debug("STOMP connection: on_message")
+                        _LOGGER.debug(frame.body)
+
+                        message = json.loads(frame.body)
+                        type = message["type"]
+                        payload = message["payload"]
+
+                        if type == "Measurement":
+                            self._tank._update_from_latest_measurement(payload)
+
+                        elif type == "Event":
+                            event = payload["event"]
+
+                            if event == "Settings":
+                                additional = json.loads(payload["additional"])
+                                self._tank._update_from_new_settings(additional)
+
+                            elif event == "Schedule":
+                                additional = json.loads(payload["additional"])
+                                self._tank._update_from_new_schedule(additional)
+
+                            elif event == "State":
+                                additional = json.loads(payload["additional"])
+                                self._tank._update_from_new_state(additional)
+
+                        self._tank._hass.loop.call_soon_threadsafe(
+                            self._tank._hass.async_create_task,
+                            self._tank._publish_updates(),
+                        )
+
+                listener = StompListener(self)
+                _LOGGER.debug("STOMP connection setting listener")
+                stomp_conn.set_listener("listener", listener)
+
+                headers = {'Token': self._token}
                 topic = f'/topic/tank/{self._uuid}/poll'
-                stomp_conn.subscribe(destination=topic, id=self._id, ack="auto")
-                _LOGGER.debug(f"STOMP subscribed to {topic}")
+                await self._hass.async_add_executor_job(
+                    self._connect_and_subscribe_stomp,
+                    stomp_conn,
+                    headers,
+                    topic,
+                )
 
+                _LOGGER.debug("STOMP connected and subscribed to %s", topic)
+                self._stomp_conn = stomp_conn
+
+            except asyncio.CancelledError:
+                raise
             except stomp.exception.ConnectFailedException:
                 _LOGGER.error("Failed to connect to Mixergy STOMP server")
-                self._hass.loop.call_later(STOMP_RETRY_TIMER, self._start_connection)
-
+                self._schedule_reconnect()
+            except (aiohttp.ClientError, TimeoutError) as e:
+                _LOGGER.warning("Network error preparing STOMP connection: %s", e)
+                self._schedule_reconnect()
             except Exception as e:
                 _LOGGER.error(f"Unexpected exception connecting to Mixergy STOMP server:\n{e}")
-                self._hass.loop.call_later(STOMP_RETRY_TIMER, self._start_connection)
-
-            self._stomp_conn = stomp_conn
+                self._schedule_reconnect()
 
         self._stomp_conn_task = self._hass.loop.create_task(_connection_runner())
+
+    @callback
+    def _schedule_reconnect(self):
+        if not self._should_connect:
+            return
+
+        if self._stomp_retry_handle is not None and not self._stomp_retry_handle.cancelled():
+            return
+
+        _LOGGER.debug("Scheduling STOMP reconnect in %s seconds", STOMP_RETRY_TIMER)
+        self._stomp_retry_handle = self._hass.loop.call_later(
+            STOMP_RETRY_TIMER,
+            self._run_scheduled_reconnect,
+        )
+
+    @callback
+    def _run_scheduled_reconnect(self):
+        self._stomp_retry_handle = None
+        self._start_connection()
+
+    def _connect_and_subscribe_stomp(self, stomp_conn, headers, topic):
+        _LOGGER.debug("STOMP connecting socket")
+        websocket_default_timeout = websocket.getdefaulttimeout()
+        try:
+            websocket.setdefaulttimeout(15)
+            stomp_conn.connect(headers=headers, with_connect_command=True)
+            _LOGGER.debug("STOMP waiting for transport connection")
+            stomp_conn.transport.wait_for_connection(timeout=60)
+            if stomp_conn.transport.socket is not None:
+                stomp_conn.transport.socket.timeout = None
+            stomp_conn.subscribe(destination=topic, id=self._id, ack="auto")
+        finally:
+            websocket.setdefaulttimeout(websocket_default_timeout)
 
     @callback
     def stop(self):
@@ -305,11 +351,24 @@ class Tank:
 
         self._should_connect = False
 
+        if self._stomp_retry_handle is not None:
+            self._stomp_retry_handle.cancel()
+            self._stomp_retry_handle = None
+
         if self._stomp_conn_task is not None:
             self._stomp_conn_task.cancel()
+            self._stomp_conn_task = None
 
         if self._stomp_conn is not None:
-            self._stomp_conn.disconnect()
+            stomp_conn = self._stomp_conn
+            self._stomp_conn = None
+            self._hass.async_create_task(self._async_disconnect(stomp_conn))
+
+    async def _async_disconnect(self, stomp_conn: stomp.WSConnection) -> None:
+        try:
+            await self._hass.async_add_executor_job(stomp_conn.disconnect)
+        except Exception as e:
+            _LOGGER.debug("Exception while disconnecting STOMP connection: %s", e)
 
     async def _authenticate(self):
 

--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -1,14 +1,19 @@
 import logging
 import asyncio
 import json
+import stomp
 from datetime import datetime
 from typing import Optional
+from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 from .const import ATTR_CHARGE
 
 _LOGGER = logging.getLogger(__name__)
 
 ROOT_ENDPOINT = "https://www.mixergy.io/api/v2"
+STOMP_ENDPOINT = "www.mixergy.io"
+STOMP_WS_PATH = "/api/v1/stomp"
+STOMP_RETRY_TIMER = 15
 
 class TankUrls:
     def __init__(self, account_url):
@@ -19,13 +24,34 @@ class Tank:
     manufacturer = "Mixergy Ltd"
 
     def __init__(self, hass, username, password, serial_number):
-        self._id = serial_number.lower()
+        self._hass = hass
+
+        # Internal data
+        self._callbacks = set()
+        self._loop = asyncio.get_event_loop()
+        self._should_connect = False
+        self._stomp_conn: stomp.WSConnection | None = None
+        self._stomp_conn_task: asyncio.Task | None = None
+
+        # Parameters
         self.username = username
         self.password = password
         self.serial_number = serial_number.upper()
-        self._hass = hass
-        self._callbacks = set()
-        self._loop = asyncio.get_event_loop()
+
+        # URLs
+        self._latest_measurement_url = ""
+        self._control_url = ""
+        self._settings_url = ""
+        self._schedule_url = ""
+
+        # Tank informatiom
+        self._id = serial_number.lower()
+        self._model_code = ""
+        self._firmware_version = "0.0.0"
+        self._uuid = ""
+        self._token = ""
+
+        # Tank settings
         self._hot_water_temperature = -1
         self._coldest_water_temperature = -1
         self._charge = -1
@@ -33,11 +59,6 @@ class Tank:
         self._indirect_heat_source = False
         self._electric_heat_source = False
         self._heatpump_heat_source = False
-        self._hasFetched = False
-        self._token = ""
-        self._latest_measurement_url = ""
-        self.model = ""
-        self.firmware_version = "0.0.0"
         self._target_temperature = -1
         self._dsr_enabled = False
         self._frost_protection_enabled = False
@@ -58,11 +79,19 @@ class Tank:
     def tank_id(self):
         return self._id
 
+    @property
+    def model_code(self):
+        return self._model_code
+
+    @property
+    def firmware_version(self):
+        return self._firmware_version
+
     async def test_authentication(self):
-        return await self.authenticate()
+        return await self._authenticate()
 
     async def test_connection(self):
-        return await self.fetch_tank_information()
+        return await self._fetch_tank_information()
     
     async def set_target_charge(self, charge):
 
@@ -76,7 +105,7 @@ class Tank:
                 _LOGGER.error("Call to %s to set the desired charge failed with status %i", self._control_url, resp.status)
                 return
 
-            await self.fetch_last_measurement()
+            await self._fetch_last_measurement()
 
     async def set_target_temperature(self, temperature):
 
@@ -90,7 +119,7 @@ class Tank:
                 _LOGGER.error("Call to %s to set the target temperature failed with status %i", self._settings_url, resp.status)
                 return
 
-            await self.fetch_settings()
+            await self._fetch_settings()
 
     async def set_dsr_enabled(self, enabled):
 
@@ -104,7 +133,7 @@ class Tank:
                 _LOGGER.error("Call to %s to set dsr (grid assistance) enabled failed with status %i", self._settings_url, resp.status)
                 return
 
-            await self.fetch_settings()
+            await self._fetch_settings()
 
     async def set_frost_protection_enabled(self, enabled):
 
@@ -118,7 +147,7 @@ class Tank:
                 _LOGGER.error("Call to %s to set frost protection enabled failed with status %i", self._settings_url, resp.status)
                 return
 
-            await self.fetch_settings()
+            await self._fetch_settings()
 
     async def set_distributed_computing_enabled(self, enabled):
 
@@ -132,7 +161,7 @@ class Tank:
                 _LOGGER.error("Call to %s to set distributed computing (medical research) enabled failed with status %i", self._settings_url, resp.status)
                 return
 
-            await self.fetch_settings()
+            await self._fetch_settings()
 
     async def set_cleansing_temperature(self, value):
 
@@ -150,7 +179,7 @@ class Tank:
                 _LOGGER.error("Call to %s to set cleansing temperature failed with status %i", self._settings_url, resp.status)
                 return
 
-            await self.fetch_settings()
+            await self._fetch_settings()
 
     async def set_divert_exported_enabled(self, enabled):
 
@@ -164,7 +193,7 @@ class Tank:
                 _LOGGER.error("Call to %s to set divert export enabled failed with status %i", self._settings_url, resp.status)
                 return
 
-            await self.fetch_settings()
+            await self._fetch_settings()
 
     async def set_pv_cut_in_threshold(self, value):
 
@@ -182,7 +211,7 @@ class Tank:
                 _LOGGER.error("Call to %s to set PV cut in threshold failed with status %i", self._control_url, resp.status)
                 return
 
-            await self.fetch_settings()
+            await self._fetch_settings()
 
     async def set_pv_charge_limit(self, value):
 
@@ -200,7 +229,7 @@ class Tank:
                 _LOGGER.error("Call to %s to set PV charge limit failed with status %i", self._control_url, resp.status)
                 return
 
-            await self.fetch_settings()
+            await self._fetch_settings()
 
     async def set_pv_target_current(self, value):
 
@@ -218,7 +247,7 @@ class Tank:
                 _LOGGER.error("Call to %s to set PV target current failed with status %i", self._control_url, resp.status)
                 return
 
-            await self.fetch_settings()
+            await self._fetch_settings()
 
     async def set_pv_over_temperature(self, value):
 
@@ -236,13 +265,105 @@ class Tank:
                 _LOGGER.error("Call to %s to set PV over temperature failed with status %i", self._control_url, resp.status)
                 return
 
-            await self.fetch_settings()
+            await self._fetch_settings()
 
-    async def authenticate(self):
+    @callback
+    def start(self):
+
+        self._should_connect = True
+
+        self._start_connection()
+
+    @callback
+    def _start_connection(self):
+
+        if not self._should_connect:
+            _LOGGER.debug("Not starting STOMP connection")
+            return
+
+        async def _connection_runner() -> None:
+            _LOGGER.debug("STOMP starting connection")
+
+            await self._authenticate()
+
+            host_tuples = [(STOMP_ENDPOINT, 443)]
+            stomp_conn = stomp.WSConnection(host_tuples, ws_path=STOMP_WS_PATH)
+            stomp_conn.set_ssl(host_tuples)
+
+            class StompListener(stomp.listener.ConnectionListener):
+                def __init__(self, tank: Tank):
+                    self._tank = tank
+
+                def on_disconnected(self):
+                    _LOGGER.debug("STOMP connection: on_disconnected")
+                    self._tank._hass.loop.call_later(STOMP_RETRY_TIMER, self._tank._start_connection)
+
+                def on_message(self, frame):
+                    _LOGGER.debug("STOMP connection: on_message")
+                    _LOGGER.debug(frame.body)
+
+                    message = json.loads(frame.body)
+                    type = message["type"]
+                    payload = message["payload"]
+
+                    if type == "Measurement":
+                        self._tank._update_from_latest_measurement(payload)
+
+                    elif type == "Event":
+                        event = payload["event"]
+
+                        if event == "Settings":
+                            additional = json.loads(payload["additional"])
+                            self._tank._update_from_new_settings(additional)
+
+                        elif event == "Schedule":
+                            additional = json.loads(payload["additional"])
+                            self._tank._update_from_new_schedule(additional)
+
+                        elif event == "State":
+                            additional = json.loads(payload["additional"])
+                            self._tank._update_from_new_state(additional)
+
+                    self._tank._hass.loop.create_task(self._tank._publish_updates())
+
+            listener = StompListener(self)
+            stomp_conn.set_listener("listener", listener)
+
+            try:
+                headers = {'Token': self._token}
+                stomp_conn.connect(wait=True, headers=headers, with_connect_command=True)
+                _LOGGER.debug("STOMP connected")
+
+                topic = f'/topic/tank/{self._uuid}/poll'
+                stomp_conn.subscribe(destination=topic, id=self._id, ack="auto")
+                _LOGGER.debug(f"STOMP subscribed to {topic}")
+
+            except stomp.exception.ConnectFailedException:
+                _LOGGER.error("Failed to connect to Mixergy STOMP server")
+                self._hass.loop.call_later(STOMP_RETRY_TIMER, self._start_connection)
+
+            self._stomp_conn = stomp_conn
+
+        self._stomp_conn_task = self._hass.loop.create_task(_connection_runner())
+
+    @callback
+    def stop(self):
+
+        _LOGGER.debug("STOMP stopping connection")
+
+        self._should_connect = False
+
+        if self._stomp_conn_task is not None:
+            self._stomp_conn_task.cancel()
+
+        if self._stomp_conn is not None:
+            self._stomp_conn.disconnect()
+
+    async def _authenticate(self):
 
         if self._token:
             _LOGGER.info("Authentication token is valid")
-            return
+            return True
 
         session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
 
@@ -279,9 +400,10 @@ class Tank:
             login_result = await resp.json()
             token = login_result['token']
             self._token = token
+
             return True
 
-    async def fetch_tank_information(self):
+    async def _fetch_tank_information(self):
 
         if self._latest_measurement_url:
             _LOGGER.info("Tank information has already been fetched")
@@ -326,7 +448,6 @@ class Tank:
                 return False
 
             tank_url = tank["_links"]["self"]["href"]
-            self.firmwareVersion = tank["firmwareVersion"]
 
             async with session.get(tank_url, headers=headers) as resp:
 
@@ -343,7 +464,9 @@ class Tank:
                 self._settings_url = tank_url_result["_links"]["settings"]["href"]
                 self._schedule_url = tank_url_result["_links"]["schedule"]["href"]
 
-                self.modelCode = tank_url_result["tankModelCode"]
+                self._uuid = tank_url_result["id"]
+                self._model_code = tank_url_result["tankModelCode"]
+                self._firmware_version = tank_url_result["firmwareVersion"]
 
                 tank_configuration_json = tank_url_result["configuration"]
                 tank_configuration = json.loads(tank_configuration_json)
@@ -359,7 +482,7 @@ class Tank:
 
                 return True
 
-    async def fetch_last_measurement(self):
+    async def _fetch_last_measurement(self, publish = False):
 
         session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
 
@@ -372,96 +495,106 @@ class Tank:
                 return
 
             tank_result = await resp.json()
-            _LOGGER.debug(tank_result)
+            self._update_from_latest_measurement(tank_result)
 
-            self._hot_water_temperature = tank_result["topTemperature"]
-            self._coldest_water_temperature = tank_result["bottomTemperature"]
+            if publish:
+                await self._publish_updates
 
-            if "pvEnergy" in tank_result:
-                self._pv_power = tank_result["pvEnergy"] / 60000
-            else:
-                self._pv_power = 0
+    def _update_from_latest_measurement(self, tank_result):
 
-            if "clampPower" in tank_result:
-                self._clamp_power = tank_result["clampPower"]
-            else:
-                self._clamp_power = 0
+        _LOGGER.debug("Updating with latest measurement data:")
+        _LOGGER.debug(tank_result)
 
-            new_charge = tank_result["charge"]
+        self._hot_water_temperature = tank_result["topTemperature"]
+        self._coldest_water_temperature = tank_result["bottomTemperature"]
 
-            _LOGGER.debug("Current: %f", self._charge)
-            _LOGGER.debug("New: %f", new_charge)
+        if "pvEnergy" in tank_result:
+            self._pv_power = tank_result["pvEnergy"] / 60000
+        else:
+            self._pv_power = 0
 
-            if new_charge != self._charge:
-                _LOGGER.debug('Sending charge_changed event')
+        if "clampPower" in tank_result:
+            self._clamp_power = tank_result["clampPower"]
+        else:
+            self._clamp_power = 0
 
-                event_data = {
-                    "device_id": self._id,
-                    "type": "charge_changed",
-                    "charge" : new_charge
-                }
+        new_charge = tank_result["charge"]
 
-                self._hass.bus.async_fire("mixergy_event", event_data)
+        _LOGGER.debug("Current: %f", self._charge)
+        _LOGGER.debug("New: %f", new_charge)
 
-            self._charge = new_charge
+        if new_charge != self._charge:
+            _LOGGER.debug('Sending charge_changed event')
 
-            # Fetch information about the current state of the heating.
+            event_data = {
+                "device_id": self._id,
+                "type": "charge_changed",
+                "charge" : new_charge
+            }
 
-            state = json.loads(tank_result["state"])
+            self._hass.bus.async_fire("mixergy_event", event_data)
 
-            current = state["current"]
+        self._charge = new_charge
 
+        # Fetch information about the current state of the heating.
+        state = json.loads(tank_result["state"])
+        self._update_from_new_state(state)
+
+    def _update_from_new_state(self, state):
+
+        current = state["current"]
+
+        new_target_charge = 0
+
+        if "target" in current:
+            new_target_charge = current["target"]
+        else:
             new_target_charge = 0
 
-            if "target" in current:
-                new_target_charge = current["target"]
-            else:
-                new_target_charge = 0
+        self._target_charge = new_target_charge
 
-            self._target_charge = new_target_charge
+        vacation = False
 
-            vacation = False
+        # Source is only present when vacation is enabled it seems
+        if "source" in current:
+            source = current["source"]
+            vacation = source == "Vacation"
 
-            # Source is only present when vacation is enabled it seems
-            if "source" in current:
-                source = current["source"]
-                vacation = source == "Vacation"
+        if vacation:
+            self._in_holiday_mode = True
 
-            if vacation:
-                self._in_holiday_mode = True
+            # Assume it's all off as the tank is in holiday mode
+            self._electric_heat_source = False
+            self._heatpump_heat_source = False
+            self._indirect_heat_source = False
 
-                # Assume it's all off as the tank is in holiday mode
+        else:
+            self._in_holiday_mode = False
+
+            heat_source = current["heat_source"].lower()
+            heat_source_on = current["immersion"].lower() == "on"
+
+            if heat_source == "indirect":
                 self._electric_heat_source = False
                 self._heatpump_heat_source = False
+                self._indirect_heat_source = heat_source_on
+
+            elif heat_source == "electric":
+                self._electric_heat_source = heat_source_on
                 self._indirect_heat_source = False
+                self._heatpump_heat_source = False
+
+            elif heat_source == "heatpump":
+                self._heatpump_heat_source = heat_source_on
+                self._indirect_heat_source = False
+                self._electric_heat_source = False
 
             else:
-                self._in_holiday_mode = False
+                self._indirect_heat_source = False
+                self._electric_heat_source = False
+                self._heatpump_heat_source = False
 
-                heat_source = current["heat_source"].lower()
-                heat_source_on = current["immersion"].lower() == "on"
-
-                if heat_source == "indirect":
-                    self._electric_heat_source = False
-                    self._heatpump_heat_source = False
-                    self._indirect_heat_source = heat_source_on
-
-                elif heat_source == "electric":
-                    self._electric_heat_source = heat_source_on
-                    self._indirect_heat_source = False
-                    self._heatpump_heat_source = False
-
-                elif heat_source == "heatpump":
-                    self._heatpump_heat_source = heat_source_on
-                    self._indirect_heat_source = False
-                    self._electric_heat_source = False
-
-                else:
-                    self._indirect_heat_source = False
-                    self._electric_heat_source = False
-                    self._heatpump_heat_source = False
-
-    async def fetch_settings(self):
+    async def _fetch_settings(self, publish = False):
 
         session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
 
@@ -477,24 +610,32 @@ class Tank:
             # Load it as a bit of JSON via the text.
             response_text = await resp.text()
             json_object = json.loads(response_text)
-            _LOGGER.debug(json_object)
+            self._update_from_new_settings(json_object)
 
-            self._target_temperature = json_object["max_temp"]
-            self._dsr_enabled = json_object["dsr_enabled"]
-            self._frost_protection_enabled = json_object["frost_protection_enabled"]
-            self._distributed_computing_enabled = json_object["distributed_computing_enabled"]
-            self._cleansing_temperature = json_object["cleansing_temperature"]
+            if publish:
+                await self._publish_updates
 
-            try:
-                self._divert_exported_enabled = json_object["divert_exported_enabled"]
-                self._pv_charge_limit = json_object["pv_charge_limit"]
-                self._pv_cut_in_threshold = json_object["pv_cut_in_threshold"]
-                self._pv_target_current = json_object["pv_target_current"]
-                self._pv_over_temperature = json_object["pv_over_temperature"]
-            except KeyError:
-                pass
+    def _update_from_new_settings(self, json_object):
 
-    async def fetch_schedule(self):
+        _LOGGER.debug("Updating with new settings:")
+        _LOGGER.debug(json_object)
+
+        self._target_temperature = json_object["max_temp"]
+        self._dsr_enabled = json_object["dsr_enabled"]
+        self._frost_protection_enabled = json_object["frost_protection_enabled"]
+        self._distributed_computing_enabled = json_object["distributed_computing_enabled"]
+        self._cleansing_temperature = json_object["cleansing_temperature"]
+
+        try:
+            self._divert_exported_enabled = json_object["divert_exported_enabled"]
+            self._pv_charge_limit = json_object["pv_charge_limit"]
+            self._pv_cut_in_threshold = json_object["pv_cut_in_threshold"]
+            self._pv_target_current = json_object["pv_target_current"]
+            self._pv_over_temperature = json_object["pv_over_temperature"]
+        except KeyError:
+            pass
+
+    async def _fetch_schedule(self, publish = False):
 
         session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
 
@@ -510,6 +651,14 @@ class Tank:
             # Load it as a bit of JSON via the text.
             response_text = await resp.text()
             json_object = json.loads(response_text)
+            self._update_from_new_schedule(json_object)
+
+            if publish:
+                await self._publish_updates
+
+    def _update_from_new_schedule(self, json_object):
+
+            _LOGGER.debug("Updating with new schedule:")
             _LOGGER.debug(json_object)
 
             self._schedule = json_object
@@ -526,11 +675,11 @@ class Tank:
                 _LOGGER.error("Call to %s to set schedule failed with status %i", self._schedule_url, resp.status)
                 return
 
-            await self.fetch_schedule()
+            await self._fetch_schedule()
 
     async def set_holiday_dates(self, start_date: datetime, end_date: datetime):
 
-        await self.fetch_schedule()
+        await self._fetch_schedule()
 
         schedule = self._schedule
 
@@ -545,11 +694,11 @@ class Tank:
 
         await self.set_schedule(schedule)
 
-        await self.publish_updates()
+        await self._publish_updates()
 
     async def clear_holiday_dates(self):
 
-        await self.fetch_schedule()
+        await self._fetch_schedule()
 
         schedule = self._schedule
 
@@ -562,7 +711,7 @@ class Tank:
 
         await self.set_schedule(schedule)
 
-        await self.publish_updates()
+        await self._publish_updates()
 
     async def set_default_heat_source(self, heat_source):
 
@@ -584,17 +733,17 @@ class Tank:
 
         _LOGGER.info('Fetching data....')
 
-        await self.authenticate()
+        await self._authenticate()
 
-        await self.fetch_tank_information()
+        await self._fetch_tank_information()
 
-        await self.fetch_last_measurement()
+        await self._fetch_last_measurement()
 
-        await self.fetch_settings()
+        await self._fetch_settings()
 
-        await self.fetch_schedule()
+        await self._fetch_schedule()
 
-        await self.publish_updates()
+        await self._publish_updates()
 
     def register_callback(self, callback):
         self._callbacks.add(callback)
@@ -602,7 +751,7 @@ class Tank:
     def remove_callback(self, callback):
         self._callbacks.discard(callback)
 
-    async def publish_updates(self):
+    async def _publish_updates(self):
         for callback in self._callbacks:
             callback()
 

--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -60,6 +60,7 @@ class Tank:
         self._electric_heat_source = False
         self._heatpump_heat_source = False
         self._target_temperature = -1
+        self._target_temperature_control_enabled = False
         self._dsr_enabled = False
         self._frost_protection_enabled = False
         self._distributed_computing_enabled = False
@@ -117,6 +118,20 @@ class Tank:
 
             if resp.status != 200:
                 _LOGGER.error("Call to %s to set the target temperature failed with status %i", self._settings_url, resp.status)
+                return
+
+            await self._fetch_settings()
+
+    async def set_target_temperature_control_enabled(self, enabled):
+
+        session = aiohttp_client.async_get_clientsession(self._hass, verify_ssl=False)
+
+        headers = {'Authorization': f'Bearer {self._token}'}
+
+        async with session.put(self._settings_url, headers=headers, json={'target_temperature_control_enabled': enabled }) as resp:
+
+            if resp.status != 200:
+                _LOGGER.error("Call to %s to set maintain target temperature enabled failed with status %i", self._settings_url, resp.status)
                 return
 
             await self._fetch_settings()
@@ -621,6 +636,7 @@ class Tank:
         _LOGGER.debug(json_object)
 
         self._target_temperature = json_object["max_temp"]
+        self._target_temperature_control_enabled = json_object["target_temperature_control_enabled"]
         self._dsr_enabled = json_object["dsr_enabled"]
         self._frost_protection_enabled = json_object["frost_protection_enabled"]
         self._distributed_computing_enabled = json_object["distributed_computing_enabled"]
@@ -794,6 +810,10 @@ class Tank:
     @property
     def target_temperature(self):
         return self._target_temperature
+
+    @property
+    def target_temperature_control_enabled(self):
+        return self._target_temperature_control_enabled
 
     @property
     def dsr_enabled(self):


### PR DESCRIPTION
This migrates the whole integration to use the STOMP over Websocket connection to Mixergy to support pushing of data rather than regular polling.

@tomasmcguinness: I wanted to put this up now, but I don't want to merge it just yet (so putting it up as a draft). I'm going to play around with it and keep testing it out. It all seems to work fine, but it's a huge change so I want to make sure I haven't missed anything. Also if you're keen to test it out, that would be amazing too.

(Fixes #48)