### PR TITLE
Fix mixergyPvType KeyError during Integration setup 

### DIFF
--- a/custom_components/mixergy/tank.py
+++ b/custom_components/mixergy/tank.py
@@ -347,7 +347,10 @@ class Tank:
 
                 tank_configuration_json = tank_url_result["configuration"]
                 tank_configuration = json.loads(tank_configuration_json)
-                self._has_pv_diverter = (tank_configuration["mixergyPvType"] != "NO_INVERTER")
+                
+                # Some tanks do not return a mixergyPvType - so force to NO_INVERTER
+                tank_configuration_pvtype = tank_configuration.get("mixergyPvType", "NO_INVERTER")
+                self._has_pv_diverter = (tank_configuration_pvtype != "NO_INVERTER")
 
                 _LOGGER.debug("Measurement URL is %s", self._latest_measurement_url)
                 _LOGGER.debug("Control URL is %s", self._control_url)


### PR DESCRIPTION
Added a check for the ``mixergyPvType`` existing in the configuration dictionary, setting it to ``NO_INVERTER`` if the key doesn't exist.

Resolves tomasmcguinness/homeassistant-mixergy#53