### PR TITLE
sensor.py: Change sensor device_class to match others

### DIFF
--- a/custom_components/mixergy/sensor.py
+++ b/custom_components/mixergy/sensor.py
@@ -198,7 +198,7 @@ class IndirectHeatSensor(BinarySensorBase):
 
 class ElectricHeatSensor(BinarySensorBase):
 
-    device_class = SensorDeviceClass.ENERGY
+    device_class = BinarySensorDeviceClass.HEAT
 
     def __init__(self, coordinator, tank:Tank):
         super().__init__( coordinator, tank)
@@ -218,7 +218,7 @@ class ElectricHeatSensor(BinarySensorBase):
 
 class HeatPumpHeatSensor(BinarySensorBase):
 
-    device_class = SensorDeviceClass.ENERGY
+    device_class = BinarySensorDeviceClass.HEAT
 
     def __init__(self, coordinator, tank:Tank):
         super().__init__( coordinator, tank)


### PR DESCRIPTION
ElectricHeatSensor and HeatPumpHeatSensor weren't using `BinarySensorDeviceClass.HEAT` but `SensorDeviceClass.ENERGY`, so this should make them consistent with other entities...

Attempts to fix https://github.com/tomasmcguinness/homeassistant-mixergy/issues/66