### PR TITLE
Add state_class to sensors to enable long-term statistics

### DIFF
--- a/custom_components/mixergy/sensor.py
+++ b/custom_components/mixergy/sensor.py
@@ -2,7 +2,7 @@ import logging
 from datetime import timedelta
 from homeassistant.const import UnitOfPower, UnitOfTemperature, PERCENTAGE, STATE_OFF
 from homeassistant.core import HomeAssistant
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.components.integration.sensor import IntegrationSensor
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from .const import DOMAIN
@@ -55,6 +55,8 @@ class BinarySensorBase(MixergyEntityBase, BinarySensorEntity):
 
 class ChargeSensor(SensorBase):
 
+    state_class = SensorStateClass.MEASUREMENT
+
     def __init__(self, coordinator, tank:Tank):
         super().__init__(coordinator, tank)
 
@@ -79,6 +81,8 @@ class ChargeSensor(SensorBase):
           return f"Current Charge"
 
 class TargetChargeSensor(SensorBase):
+
+    state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, tank:Tank):
         super().__init__(coordinator, tank)
@@ -106,6 +110,7 @@ class TargetChargeSensor(SensorBase):
 class HotWaterTemperatureSensor(SensorBase):
 
     device_class = SensorDeviceClass.TEMPERATURE
+    state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, tank:Tank):
         super().__init__( coordinator, tank)
@@ -130,6 +135,7 @@ class HotWaterTemperatureSensor(SensorBase):
 class ColdestWaterTemperatureSensor(SensorBase):
 
     device_class = SensorDeviceClass.TEMPERATURE
+    state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, tank:Tank):
         super().__init__(coordinator, tank)
@@ -153,6 +159,7 @@ class ColdestWaterTemperatureSensor(SensorBase):
 class TargetTemperatureSensor(SensorBase):
 
     device_class = SensorDeviceClass.TEMPERATURE
+    state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, tank:Tank):
         super().__init__(coordinator, tank)
@@ -305,7 +312,7 @@ class IsChargingSensor(BinarySensorBase):
 class PowerSensor(SensorBase):
 
     device_class = SensorDeviceClass.POWER
-    state_class = "measurement"
+    state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, tank:Tank):
         super().__init__(coordinator,tank)
@@ -349,7 +356,7 @@ class EnergySensor(IntegrationSensor):
 class PVPowerSensor(SensorBase):
 
     device_class = SensorDeviceClass.POWER
-    state_class = "measurement"
+    state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, tank:Tank):
         super().__init__(coordinator,tank)
@@ -402,7 +409,7 @@ class PVEnergySensor(IntegrationSensor):
 class ClampPowerSensor(SensorBase):
 
     device_class = SensorDeviceClass.POWER
-    state_class = "measurement"
+    state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, tank:Tank):
         super().__init__(coordinator,tank)


### PR DESCRIPTION
## Summary

Rebased/clean version of #87, per feedback from @reedy to avoid unrelated commits picked up via merge history.

- Added `SensorStateClass.MEASUREMENT` to `ChargeSensor`, `TargetChargeSensor`, `HotWaterTemperatureSensor`, `ColdestWaterTemperatureSensor`, and `TargetTemperatureSensor`, which were missing `state_class` entirely
- Updated `PowerSensor`, `PVPowerSensor`, and `ClampPowerSensor` to use the `SensorStateClass.MEASUREMENT` enum instead of the raw string `"measurement"`
- Imported `SensorStateClass` from `homeassistant.components.sensor`

Without `state_class`, Home Assistant does not record long-term statistics for these sensors, so historical data is unavailable in the Energy dashboard and statistics graphs.

Supersedes #87.

## Test plan

- [x] Restart Home Assistant with the updated integration
- [x] Verify sensors appear without warnings in the HA logs
- [x] Confirm long-term statistics are recorded for temperature and charge sensors