### PR TITLE
Fix MixergyEntityBase double-polling as a CoordinatorEntity

### DIFF
--- a/custom_components/mixergy/mixergy_entity.py
+++ b/custom_components/mixergy/mixergy_entity.py
@@ -4,7 +4,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 class MixergyEntityBase(CoordinatorEntity):
 
-    should_poll = True
+    should_poll = False
 
     def __init__(self, coordinator, tank:Tank):
         super().__init__(coordinator)        

--- a/custom_components/mixergy/mixergy_entity.py
+++ b/custom_components/mixergy/mixergy_entity.py
@@ -26,6 +26,7 @@ class MixergyEntityBase(CoordinatorEntity):
         return self._tank.online
 
     async def async_added_to_hass(self):
+        await super().async_added_to_hass()
         self._tank.register_callback(self.async_write_ha_state)
 
     async def async_will_remove_from_hass(self):


### PR DESCRIPTION
## Problem
`MixergyEntityBase` extends `CoordinatorEntity` but:
1. Overrides `should_poll = True`, so every entity independently triggers its own coordinator refresh *in addition to* the coordinator's own scheduled 30s refresh — roughly doubling the effective poll rate against the Mixergy cloud API.
2. Overrides `async_added_to_hass()` without calling `super().async_added_to_hass()`, so the entity never registers as a coordinator listener via the standard `CoordinatorEntity` mechanism.

These two bugs mask each other: `should_poll=True` happens to keep data flowing (via each entity's own poll cycle) despite the broken listener registration, but at ~2x the intended request rate.

Observed in production: `Fetching data from Mixergy...` logged every ~15s instead of the configured 30s, and `sensor.hot_water_temperature` periodically logged `Update ... is taking over 10 seconds`.

## Fix
- `should_poll = False` — correct for a `CoordinatorEntity`; updates should come from the coordinator's push, not per-entity polling.
- Add `await super().async_added_to_hass()` — registers the entity as a coordinator listener so it actually receives push updates.

Fixing only #1 without #2 was tested and breaks live updates entirely (entities freeze after the initial refresh) — both changes are required together.

## Testing
Verified against a live instance:
- Fetch cadence dropped from ~15s to a steady ~30-40s (matching `update_interval=30s` plus network round-trip)
- `sensor.hot_water_temperature.last_reported` confirmed still advancing every cycle (entities not frozen)